### PR TITLE
Adding functionality to allow users to search for a specific XKCD comic ...

### DIFF
--- a/lib/xkcd.rb
+++ b/lib/xkcd.rb
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
 require 'nokogiri'
 require 'open-uri'
-require 'json'
+require 'json' 
+require 'google-search'
+require 'uri'
 
 # The main XKCD driver
 class XKCD
@@ -18,6 +20,22 @@ class XKCD
         open('http://dynamic.xkcd.com/random/comic/').base_uri.to_s
     end
     
+    def self.search(query)      
+      comic_id = 149 #Default to make me a sandwich if nothing can be found
+      Google::Search::Web.new(:query => "xkcd " + query).each do |result|
+         current_url = URI(result.uri) #Parse the search result URL
+         if current_url.hostname == "xkcd.com" #Ignore all of URLs which are not from XKCD.com
+           id = current_url.path.gsub(/\//, "").to_i #Checking to make sure that only a URL with a comic strip ID is taken
+           if id != 0
+             comic_id = id
+             break 
+           end
+         end
+      end
+      
+       self.get_comic(comic_id)
+    end
+    
     class << XKCD
         alias_method :get, :comic
     end
@@ -30,11 +48,15 @@ class XKCD
         "#{img_title} : #{img_url}"
     end
 =end
-    def self.img
+    def self.img        
         max = JSON.parse(open('http://xkcd.com/info.0.json').read)["num"]
         comic_num = 1 + rand(max-1) 
         comic_num = 1 if comic_num == 404 # Avoid 404th comic ;)
-        comic = JSON.parse(open("http://xkcd.com/#{comic_num}/info.0.json").read)
-        "#{comic['alt']} : #{comic['img']}"    
+        self.get_comic(comic_num)    
+    end
+    
+    def self.get_comic(id)
+      comic = JSON.parse(open("http://xkcd.com/#{id}/info.0.json").read)
+      "#{comic['alt']} : #{comic['img']}"
     end
 end

--- a/spec/xkcd_spec.rb
+++ b/spec/xkcd_spec.rb
@@ -26,7 +26,31 @@ describe XKCD do
   #
   describe "img" do
     it "should return the ALT text and URI of the image for a random comic" do
-      XKCD.img.must_match /^.+ : http:\/\/imgs\.xkcd\.com\/comics\/.+\.(png|jpg)$/
+       XKCD.img.must_match /^.+ : http:\/\/imgs\.xkcd\.com\/comics\/.+\.(png|jpg)$/
     end
+  end
+  
+  # The get_comic method
+  #
+  describe "get_comic" do
+    it "should return the ALT text and URI of the image for a specific comic" do
+      comic = XKCD.get_comic(403)
+      comic.must_match /^.+ : http:\/\/imgs\.xkcd\.com\/comics\/.+\.(png|jpg)$/
+      assert(comic.include?("http://imgs.xkcd.com/comics/convincing_pickup_line.png"))
+    end
+  end
+  
+  describe "search" do
+     it "should be able to find a desired comic" do
+       expected = "Okay, Lance.  For entry into the college bowl, spell 'Throbbing' : http://imgs.xkcd.com/comics/rule_34.png"
+       actual = XKCD.search("rule 34")
+       assert_equal(expected, actual)
+     end
+     
+     it "should default to make me a sandwich on a bad search" do
+       expected = "Proper User Policy apparently means Simon Says. : http://imgs.xkcd.com/comics/sandwich.png"
+       actual = XKCD.search("asldkfjaslkdjflaksjfdlwjkef")   
+       assert_equal(expected, actual)
+     end  
   end
 end

--- a/xkcd.gemspec
+++ b/xkcd.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.6.2}
   s.add_dependency('nokogiri', '>= 1.5.0')
+  s.add_dependency('google-search')
   s.summary = %q{XCKD random img urls!}
   s.bindir = 'bin'
   s.executables = 'xkcd'


### PR DESCRIPTION
- Refactored part of img method into get_comic method
- Added a test for get_comic method
- Added google-search gem dependency
- Do a simple loop through xkcd specific urls in a google search
- Added test for google search method

This feature would be great if you can merge it, will make my lita hipchat bot really happy!
